### PR TITLE
Fix off-by-one mode wraparound

### DIFF
--- a/pwm_snowflake_v1_1/pwm_snowflake_v1_1.ino
+++ b/pwm_snowflake_v1_1/pwm_snowflake_v1_1.ino
@@ -67,7 +67,7 @@ void initConfig()
 {
   mode = eeprom_read(0);
   mode++;
-  if (mode >= maxMode) mode = 0; 
+  if (mode > maxMode) mode = 0;
   eeprom_write(0, mode);
 }
 


### PR DESCRIPTION
## Summary
- correct logic that advances the pattern mode stored in EEPROM

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68797f7f27988322bd05db33411c525b